### PR TITLE
Return body chunks before boundary

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -410,11 +410,15 @@ where
                                 mem::replace(&mut self_mut.buffer, Vec::new()),
                             )))));
                         }
+                    } else {
+                        let mut buffer = self_mut.buffer.split_off(idx + 1);
+                        mem::swap(&mut self_mut.buffer, &mut buffer);
+                        return Poll::Ready(Some(Ok(ParseOutput::Bytes(buffer.into()))));
                     }
                 }
 
                 //If we didn't find an `\r` in any of the multiparts, just take out the buffer and return as bytes
-                let buffer = mem::replace(&mut self_mut.buffer, Vec::new());
+                let buffer = mem::take(&mut self_mut.buffer);
 
                 return Poll::Ready(Some(Ok(ParseOutput::Bytes(Bytes::from(buffer)))));
             }

--- a/src/server.rs
+++ b/src/server.rs
@@ -578,11 +578,10 @@ mod tests {
 
         let ret = block_on(read.next());
 
-        assert!(
-            matches!(ret, Some(Err(MultipartError::EOFWhileReadingHeaders))),
-            "{:?}",
-            ret
-        );
+        assert!(matches!(
+            ret,
+            Some(Err(MultipartError::EOFWhileReadingHeaders))
+        ),);
     }
     #[test]
     fn unfinished_second_header() {
@@ -610,11 +609,10 @@ mod tests {
 
         let ret = block_on(read.next());
 
-        assert!(
-            matches!(ret, Some(Err(MultipartError::EOFWhileReadingHeaders))),
-            "{:?}",
-            ret
-        );
+        assert!(matches!(
+            ret,
+            Some(Err(MultipartError::EOFWhileReadingHeaders))
+        ),);
     }
     #[test]
     fn invalid_header() {

--- a/src/server.rs
+++ b/src/server.rs
@@ -665,16 +665,15 @@ mod tests {
     fn zero_read() {
         use bytes::{BufMut, BytesMut};
 
-        let input = b"\
-----------------------------332056022174478975396798\r\n\
-Content-Disposition: form-data; name=\"file\"\r\n\
-Content-Type: application/octet-stream\r\n\
-\r\n\
-\r\n\
-\r\n\
-dolphin\n\
-whale\r\n\
-----------------------------332056022174478975396798--\r\n";
+        let input = b"----------------------------332056022174478975396798\r\n\
+                Content-Disposition: form-data; name=\"file\"\r\n\
+                Content-Type: application/octet-stream\r\n\
+                \r\n\
+                \r\n\
+                \r\n\
+                dolphin\n\
+                whale\r\n\
+                ----------------------------332056022174478975396798--\r\n";
 
         let boundary = "--------------------------332056022174478975396798";
 


### PR DESCRIPTION
Ended up making a lot of changes to help debugging this thing and while thinking about the issue and thus tried to clean up as much as possible. Still, quite a lot of changes remained:

 - the code now supports returning small chunks in the case of `\r` in the body (see #7)
 - inner stream is advanced only when necessary (loop + State boolean)
 - few new error cases which were previously silently ignored (test cases adjusted accordingly)

Any ideas welcome to combat the big change. I was thinking about separating a "tokenizer" but that would had been even a bigger change.

Changes considered but not included or removed while cleaning up:

 - removal of `anyhow` usage
 - replacing Vec buffer with BytesMut
 - testing with arbitary sized chunks

Fixes #7. CC: @cetra3.