### PR TITLE
Slim down dependencies and use `tokio::test` to asyncify tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,15 @@ edition = "2018"
 
 [dependencies]
 bytes = "0.5"
-futures = "0.3"
+futures-core = "0.3"
+futures-util = { version = "0.3", default-features = false }
 rand = "0.7"
 log = "0.4.1"
 httparse = "1.3.4"
 http = "0.2.0"
 twoway = "0.2.1"
-tokio = {version = "0.2.10", optional = true, features= ["fs", "rt-threaded", "macros", "stream"]}
-tokio-util = {version = "0.2", optional = true, features= ["codec"]}
+tokio = { version = "0.2", optional = true, features= ["fs", "stream"] }
+tokio-util = { version = "0.3", optional = true, features= ["codec"] }
 mime_guess = {version = "2.0.1", optional = true}
 thiserror = "1.0"
 pin-project = "0.4.22"
@@ -29,6 +30,7 @@ mime = "0.3.16"
 headers = "0.3.2"
 criterion = "0.3"
 rand = "0.7"
+tokio = { version = "0.2", features = ["rt-threaded", "macros"] }
 
 [features]
 default = [

--- a/examples/warp.rs
+++ b/examples/warp.rs
@@ -1,8 +1,8 @@
 use warp::Filter;
 
 use bytes::Buf;
-use futures::stream::TryStreamExt;
-use futures::Stream;
+use futures_core::Stream;
+use futures_util::TryStreamExt;
 use mime::Mime;
 use mpart_async::server::MultipartStream;
 use std::convert::Infallible;

--- a/src/filestream.rs
+++ b/src/filestream.rs
@@ -1,4 +1,4 @@
-use futures::Stream;
+use futures_core::Stream;
 use std::path::PathBuf;
 use tokio::fs::File;
 use tokio_util::codec::{BytesCodec, FramedRead};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,8 +66,8 @@
 //! use warp::Filter;
 //!
 //! use bytes::Buf;
-//! use futures::stream::TryStreamExt;
-//! use futures::Stream;
+//! use futures_util::TryStreamExt;
+//! use futures_core::Stream;
 //! use mime::Mime;
 //! use mpart_async::server::MultipartStream;
 //! use std::convert::Infallible;


### PR DESCRIPTION
The PR slims down the dependencies by depending only on `futures-core`, `futures-util` and moving tokio's runtime features to the dev-dependencies. It also changes the async tests to use `#[tokio::test]`.

