### PR TITLE
Improved filename parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tokio-util = { version = "0.6", optional = true, features= ["codec"] }
 mime_guess = {version = "2.0.1", optional = true}
 thiserror = "1.0"
 pin-project = "1.0"
+percent-encoding = "2.1.0"
 
 [dev-dependencies]
 hyper = "0.14"


### PR DESCRIPTION
The filename parameter is now parsed as utf-8, and \" is unescaped and
percent encoded charaters are decoded.

Change-Id: I9073f815a77178bbcf9773c550b77fd9cbecc54f