### PR TITLE
http 1.0.0 for hyper 1.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ futures-util = { version = "0.3", default-features = false }
 rand = "0.8"
 log = "0.4.1"
 httparse = "1.6.0"
-http = "0.2.0"
+http = "1.0.0"
 memchr = "2.4.1"
 tokio = { version = "1.0", optional = true, features= ["fs"] }
 tokio-util = { version = "0.6", optional = true, features= ["codec"] }


### PR DESCRIPTION
I'd like to use mpart-async  in hyper 1.x.
mpart-async should expose `HeaderValue` in http 1.0 for hyper 1.x.

I used hyper 1.x with the updated mpart-async in local and it worked.